### PR TITLE
New fix typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### 0.4.1 (2020-02-04)
+
+
+### Features
+
+* Better config parsing ([0d3209c](https://github.com/pop-os/pyflatpak/commit/0d3209cd0a462374d77c6257aeadf7da69478b62))
+
+
+### Bug Fixes
+
+* Fix spelling of "homepage" key ([87c3478](https://github.com/pop-os/pyflatpak/commit/87c3478d132bc49e57ab6104289086a00c9af31d))
+* Merge pull request [#1](https://github.com/pop-os/pyflatpak/issues/1) from pop-os/logging-spam ([55c1a2b](https://github.com/pop-os/pyflatpak/commit/55c1a2b0e07ff976277d832d1b4d0370360facba))
+* Stop creating a new log file in cwd every time we run ([f6e1e45](https://github.com/pop-os/pyflatpak/commit/f6e1e45eeab0847a8bcae346c8be1c739c153e7b))
+
 ## [0.4.0](https://github.com/pop-os/pyflatpak/compare/v0.3.1...v0.4.0) (2020-01-29)
 
 ### [0.3.2](https://github.com/pop-os/pyflatpak/compare/v0.3.1...v0.3.2) (2020-01-29)

--- a/debian/changelog
+++ b/debian/changelog
@@ -2,25 +2,25 @@ python3-pyflatpak (0.4.1) eoan; urgency=medium
 
   * The "homepage" key for remotes was spelled incorrectly. This is fixed.
 
- -- Ian Santopiero <ian@pop-os.localdomain>  Tue, 04 Feb 2020 11:42:13 -0700
+ -- Ian Santopiero <ian@system76.com>  Tue, 04 Feb 2020 11:42:13 -0700
 
 python3-pyflatpak (0.4.0) eoan; urgency=medium
 
   * Bump version to correct issues with automatic versioning
 
- -- Ian Santopiero <ian@pop-os.localdomain>  Wed, 29 Jan 2020 11:59:56 -0700
+ -- Ian Santopiero <ian@system76.com>  Wed, 29 Jan 2020 11:59:56 -0700
 
 python3-pyflatpak (0.3.2) eoan; urgency=medium
 
   * Version bump
 
- -- Ian Santopiero <ian@pop-os.localdomain>  Wed, 29 Jan 2020 11:48:24 -0700
+ -- Ian Santopiero <ian@system76.com>  Wed, 29 Jan 2020 11:48:24 -0700
 
 python3-pyflatpak (0.3.0) eoan; urgency=medium
 
   * Fetches Icons and Hompage of repos if available
 
- -- Ian Santopiero <ian@pop-os.localdomain>  Wed, 29 Jan 2020 11:43:04 -0700
+ -- Ian Santopiero <ian@system76.com>  Wed, 29 Jan 2020 11:43:04 -0700
 
 python3-pyflatpak (0.1.0) eoan; urgency=medium
 
@@ -29,7 +29,7 @@ python3-pyflatpak (0.1.0) eoan; urgency=medium
   * Now supports an 'about' field for each remote
   * Fixed title support
 
- -- Ian Santopiero <ian@pop-os.localdomain>  Wed, 29 Jan 2020 11:35:14 -0700
+ -- Ian Santopiero <ian@system76.com>  Wed, 29 Jan 2020 11:35:14 -0700
 
 python3-pyflatpak (0.0.2) eoan; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+python3-pyflatpak (0.4.1) eoan; urgency=medium
+
+  * The "homepage" key for remotes was spelled incorrectly. This is fixed.
+
+ -- Ian Santopiero <ian@pop-os.localdomain>  Tue, 04 Feb 2020 11:42:13 -0700
+
 python3-pyflatpak (0.4.0) eoan; urgency=medium
 
   * Bump version to correct issues with automatic versioning

--- a/pyflatpak/remotes.py
+++ b/pyflatpak/remotes.py
@@ -126,7 +126,7 @@ class Remotes():
                 current_remotes[remote_name]['option'] = option
                 current_remotes[remote_name]['about'] = remote_about
                 current_remotes[remote_name]['icon'] = icon
-                current_remotes[remote_name]['hompage'] = remote_homepage
+                current_remotes[remote_name]['homepage'] = remote_homepage
         
         return (option, current_remotes)
     


### PR DESCRIPTION
Changes the name of the "homepage" key in remotes from "hompage" to "homepage". This will make it easier to develop for in the future because the keys will be named intuitively.

Fixes #4 